### PR TITLE
[#113] #104 画像の読み込み速度の向上を考える」を改善する: UICollectionViewを右から左にスクロールできるようにする

### DIFF
--- a/Pendula/View/Component/018_LoadImages/LoadImages.storyboard
+++ b/Pendula/View/Component/018_LoadImages/LoadImages.storyboard
@@ -16,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="4yN-Ms-vR4">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="4yN-Ms-vR4">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="lEC-Hx-eL1">


### PR DESCRIPTION
## Issue

- #113 
  
## やったこと
- UICollectionViewを右から左にスクロールできるようにした
  
## スクリーンショット
  
|  before  |  after  |
| ---- | ---- |
| ![](https://user-images.githubusercontent.com/37968814/144741807-06ea560d-6652-4ae2-bcd5-f75602a8f723.gif)  | ![](https://user-images.githubusercontent.com/37968814/144741747-8791cb5d-656a-4ae9-a2c4-ba92362fdd77.gif) |
  
## やらないこと
None

## 動作確認
- 018_LoadImages画面に遷移してUICollectionViewを右から左にスクロール
  
## レビューレベル
  
- [ ] Lv3: プロジェクト全体の動作に問題がないか確認する  
- [ ] Lv2: 影響があるコンポーネントの動作に問題がないか確認する  
- [x] Lv1: ぱっと見て問題ないか確認する  
  