### PR TITLE
[#116] 連続的ではなく離散的にスクロールできるようにする

### DIFF
--- a/Pendula/View/Component/018_LoadImages/LoadImages.storyboard
+++ b/Pendula/View/Component/018_LoadImages/LoadImages.storyboard
@@ -16,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="4yN-Ms-vR4">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="4yN-Ms-vR4">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="lEC-Hx-eL1">

--- a/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
@@ -56,10 +56,10 @@ final class LoadImagesFlowLayout: UICollectionViewFlowLayout {
             return
         }
 
-        // TODO: [#116] -10, 10で上手く行った。 説明できるようにする
-        let expandedVisibleRect = CGRect(x: max(0, collectionView.contentOffset.x - 10),
+        // 見えてないCellも考慮するため、現在のoffsetの後ろから見るようにする
+        let expandedVisibleRect = CGRect(x: collectionView.contentOffset.x - collectionView.bounds.width,
                                          y: 0,
-                                         width: collectionView.bounds.width + 10,
+                                         width: collectionView.bounds.width * 2,
                                          height: collectionView.bounds.height)
 
         layoutAttributesForPaging = layoutAttributesForElements(in: expandedVisibleRect)?.sorted { $0.frame.minX < $1.frame.minX }

--- a/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
@@ -1,0 +1,67 @@
+//
+//  LoadImagesFlowLayout.swift
+//  Pendula
+//
+//  Created by tokizo on 2021/12/09.
+//
+
+import UIKit
+
+final class LoadImagesFlowLayout: UICollectionViewFlowLayout {
+
+    private var layoutAttributesForPaging: [UICollectionViewLayoutAttributes]?
+
+    override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint,
+                                      withScrollingVelocity velocity: CGPoint) -> CGPoint {
+        guard let collectionView = collectionView,
+              let targetAttributes = layoutAttributesForPaging else {
+            return proposedContentOffset
+        }
+
+        let nextAttributes: UICollectionViewLayoutAttributes?
+        if velocity.x == 0 {
+            nextAttributes = layoutAttributesForNearbyCenterX(in: targetAttributes, collectionView: collectionView)
+
+        } else if velocity.x > 0 {
+            nextAttributes = targetAttributes.last
+
+        } else {
+            nextAttributes = targetAttributes.first
+        }
+
+        guard let attributes = nextAttributes else {
+            return proposedContentOffset
+        }
+
+        let cellLeftMargin = (collectionView.bounds.width - attributes.bounds.width) * 0.5
+        return CGPoint(x: attributes.frame.minX - cellLeftMargin, y: collectionView.contentOffset.y)
+    }
+
+    private func layoutAttributesForNearbyCenterX(in attributes: [UICollectionViewLayoutAttributes],
+                                                  collectionView: UICollectionView) -> UICollectionViewLayoutAttributes? {
+        let screenCenterX = collectionView.contentOffset.x + collectionView.bounds.width * 0.5
+
+        let result = attributes.reduce((attributes: nil as UICollectionViewLayoutAttributes?,
+                                        distance: CGFloat.infinity)) { result, attributes in
+            let distance = attributes.frame.midX - screenCenterX
+            return abs(distance) < abs(result.distance) ? (attributes, distance) : result
+        }
+
+        return result.attributes
+    }
+
+    func prepareForPaging() {
+        guard let collectionView = collectionView else {
+            return
+        }
+
+        // TODO: [#116] -10, 10で上手く行った。 cellの大きさがcollectionView
+        let expandedVisibleRect = CGRect(x: max(0, collectionView.contentOffset.x - 10),
+                                         y: 0,
+                                         width: collectionView.bounds.width + 10,
+                                         height: collectionView.bounds.height)
+
+        layoutAttributesForPaging = layoutAttributesForElements(in: expandedVisibleRect)?.sorted { $0.frame.minX < $1.frame.minX }
+    }
+
+}

--- a/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
@@ -20,14 +20,15 @@ final class LoadImagesFlowLayout: UICollectionViewFlowLayout {
         }
 
         let nextAttributes: UICollectionViewLayoutAttributes?
-        if velocity.x == 0 {
-            nextAttributes = layoutAttributesForNearbyCenterX(in: targetAttributes, collectionView: collectionView)
+        if velocity.x < 0 {
+            nextAttributes = targetAttributes.first
 
-        } else if velocity.x > 0 {
-            nextAttributes = targetAttributes.last
+        } else if velocity.x == 0 {
+            nextAttributes = layoutAttributesForNearbyCenterX(in: targetAttributes,
+                                                              collectionView: collectionView)
 
         } else {
-            nextAttributes = targetAttributes.first
+            nextAttributes = targetAttributes.last
         }
 
         guard let attributes = nextAttributes else {

--- a/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
@@ -55,7 +55,7 @@ final class LoadImagesFlowLayout: UICollectionViewFlowLayout {
             return
         }
 
-        // TODO: [#116] -10, 10で上手く行った。 cellの大きさがcollectionView
+        // TODO: [#116] -10, 10で上手く行った。 説明できるようにする
         let expandedVisibleRect = CGRect(x: max(0, collectionView.contentOffset.x - 10),
                                          y: 0,
                                          width: collectionView.bounds.width + 10,

--- a/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class LoadImagesFlowLayout: UICollectionViewFlowLayout {
 
+    /// ページスクロールに必要なスクロール対象の UICollectionViewLayoutAttributes を保持
     private var layoutAttributesForPaging: [UICollectionViewLayoutAttributes]?
 
     override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint,

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -13,7 +13,6 @@ final class LoadImagesViewController: ComponentBaseViewController {
         didSet {
             collectionView.dataSource = self
             collectionView.register(R.nib.loadImagesCollectionViewCell)
-            configureFlowLayout()
         }
     }
 
@@ -30,6 +29,11 @@ final class LoadImagesViewController: ComponentBaseViewController {
         configureNavigationItem(navigationTitle: "018 LoadImages")
         collectionView.isHidden = true
         presenter.getImages()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        configureFlowLayout()
     }
 
 }

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -12,6 +12,8 @@ final class LoadImagesViewController: ComponentBaseViewController {
     @IBOutlet weak var collectionView: UICollectionView! {
         didSet {
             collectionView.dataSource = self
+            collectionView.delegate = self
+            collectionView.decelerationRate = .fast
             collectionView.register(R.nib.loadImagesCollectionViewCell)
         }
     }
@@ -22,7 +24,8 @@ final class LoadImagesViewController: ComponentBaseViewController {
 
     private var viewControllerModel: ViewControllerModel?
     var presenter: LoadImagesPresenter!
-    private let cellCount = 300
+    private let cellCount = 5
+    private lazy var flowLayout = LoadImagesFlowLayout()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -76,12 +79,20 @@ extension LoadImagesViewController: LoadImagesPresenterOutput {
 extension LoadImagesViewController {
 
     private func configureFlowLayout() {
-        let layout = UICollectionViewFlowLayout()
+        let layout = flowLayout
         layout.itemSize = .init(width: collectionView.frame.width,
                                 height: collectionView.frame.height)
         layout.scrollDirection = .horizontal
         layout.minimumLineSpacing = 0
         collectionView.collectionViewLayout = layout
+    }
+
+}
+
+extension LoadImagesViewController: UICollectionViewDelegateFlowLayout {
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        flowLayout.prepareForPaging()
     }
 
 }

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -76,6 +76,7 @@ extension LoadImagesViewController {
         layout.itemSize = .init(width: collectionView.frame.width,
                                 height: collectionView.frame.height)
         layout.scrollDirection = .horizontal
+        layout.minimumLineSpacing = 0
         collectionView.collectionViewLayout = layout
     }
 

--- a/Pendula/View/VerificationList/VerificationListViewController.swift
+++ b/Pendula/View/VerificationList/VerificationListViewController.swift
@@ -96,7 +96,7 @@ extension VerificationListViewController {
                          lastUpdateDate: "2021.11.21".date(format: .yyyyMMddPd),
                          viewController: ClipPictureBuilder().build()),
             Verification(title: "画像の読み込み速度の向上を考える",
-                         lastUpdateDate: "2021.11.26".date(format: .yyyyMMddPd),
+                         lastUpdateDate: "2021.12.11".date(format: .yyyyMMddPd),
                          viewController: LoadImagesBuilder().build())
         ]
 


### PR DESCRIPTION
## Issue
#116 
  
## やったこと
- ページスクロールを導入した
   - ピタッと止まるスクロール（≒ 離散的に止まる）
  
## スクリーンショット

| before | after |
| --- | --- | 
|  ![before](https://user-images.githubusercontent.com/37968814/145662574-931df87f-fb1e-4c6a-97a7-0469550ee15a.gif) | ![after](https://user-images.githubusercontent.com/37968814/145662508-a385e0d0-f5bc-42b6-8c63-59e015edbead.gif) |
 
ページスクロールの導入に際し、スクロール方向をデフォルトにしたほうが計算が楽なため、本PRではデフォルトのスクロール方向の前提で実装した。逆にするのは後で対応する。↓再オープンした
- #113

## やらないこと

- スクロール方向を逆にする
    - #113 
  
## 動作確認
018コンポーネントに遷移してUICollectionViewをスクロール
  
## レビューレベル
  
- [ ] Lv3: プロジェクト全体の動作に問題がないか確認する  
- [ ] Lv2: 影響があるコンポーネントの動作に問題がないか確認する  
- [x] Lv1: ぱっと見て問題ないか確認する  
  
## 参考
- [UICollectionViewでページングスクロールを実装する - クックパッド開発者ブログ](https://techlife.cookpad.com/entry/2019/08/16/090000)
  
## 備考
本PRはページスクロールの導入PRで、細かな修正は別issueを切って対応する。（このPRでは対応しない。なぜならPRが大きくなりすぎてしまうため。）
