### PR TITLE
[#118] 読み込み時にindicatorを走らせるようにする

### DIFF
--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -54,14 +54,14 @@ extension LoadImagesViewController: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let viewControllerModel = viewControllerModel else {
+        guard let viewControllerModel = viewControllerModel,
+              viewControllerModel.thumbnailImages.indices.contains(indexPath.row) else {
             return UICollectionViewCell()
         }
 
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: R.reuseIdentifier.loadImagesCollectionViewCell,
                                                       for: indexPath)!
-        let index = indexPath.row % viewControllerModel.thumbnailImages.count
-        let image = viewControllerModel.thumbnailImages[index]
+        let image = viewControllerModel.thumbnailImages[indexPath.row]
         let laps = indexPath.row / viewControllerModel.thumbnailImages.count
         cell.setup(viewModel: .init(image: image,
                                     rowText: indexPath.row.description,

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -26,12 +26,14 @@ final class LoadImagesViewController: ComponentBaseViewController {
     var presenter: LoadImagesPresenter!
     private let cellCount = 5
     private lazy var flowLayout = LoadImagesFlowLayout()
+    private lazy var activityIndicatorView = UIActivityIndicatorView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigationItem(navigationTitle: "018 LoadImages")
         collectionView.isHidden = true
-        presenter.getImages()
+        configureIndicator()
+        activityIndicatorView.startAnimating()
     }
 
     override func viewDidLayoutSubviews() {
@@ -39,12 +41,17 @@ final class LoadImagesViewController: ComponentBaseViewController {
         configureFlowLayout()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        presenter.getImages()
+    }
+
 }
 
 extension LoadImagesViewController: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return cellCount
+        return viewControllerModel?.thumbnailImages.count ?? 0
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -69,6 +76,8 @@ extension LoadImagesViewController: LoadImagesPresenterOutput {
 
     func updateViewControllerModel(_ viewControllerModel: ViewControllerModel) {
         self.viewControllerModel = viewControllerModel
+        activityIndicatorView.stopAnimating()
+        activityIndicatorView.removeFromSuperview()
         collectionView.isHidden = false
         collectionView.reloadData()
     }
@@ -85,6 +94,16 @@ extension LoadImagesViewController {
         layout.scrollDirection = .horizontal
         layout.minimumLineSpacing = 0
         collectionView.collectionViewLayout = layout
+    }
+
+}
+
+// MARK: - Configure UIActivityIndicatorView
+extension LoadImagesViewController {
+
+    private func configureIndicator() {
+        activityIndicatorView.center = view.center
+        view.addSubview(activityIndicatorView)
     }
 
 }

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -24,7 +24,6 @@ final class LoadImagesViewController: ComponentBaseViewController {
 
     private var viewControllerModel: ViewControllerModel?
     var presenter: LoadImagesPresenter!
-    private let cellCount = 5
     private lazy var flowLayout = LoadImagesFlowLayout()
     private lazy var activityIndicatorView = UIActivityIndicatorView()
 


### PR DESCRIPTION
## Issue
- #118 
  
## やったこと

- 018コンポーネント画面に UIActivityIndicator を導入した
   - ユーザーに読み込んでます感をアピールするため
  
## スクリーンショット
  
|  before  |  after  |
| ---- | ---- |
|  ![before](https://user-images.githubusercontent.com/37968814/145698382-b9e52c3a-f287-47d6-9c14-914cc655809f.gif)  |  ![after](https://user-images.githubusercontent.com/37968814/145698364-49c0ba3e-5884-4407-b7c4-139f4bb7f605.gif)  |
  
### before
セルタップ→018コンポーネント画面に遷移するまでに時間がかかっていて、ユーザーに待たせてしまってる感が強くて良くない。

### after
セルタップ→018コンポーネント画面に遷移の速度を上げた。セルの情報を読み込み終わるまではUIActivityIndicatorを表示させることによって読み込んでます感を出させている。

## やらないこと

- UIActivityIndicator導入によりフラグの管理が多くなってきたので別issueでどうにかする。どのように改善するかもそのissueで考える。
   - #122 
  
## 動作確認
018コンポーネントに遷移する
  
## レビューレベル
  
- [ ] Lv3: プロジェクト全体の動作に問題がないか確認する  
- [ ] Lv2: 影響があるコンポーネントの動作に問題がないか確認する  
- [x] Lv1: ぱっと見て問題ないか確認する  
  
## 参考
None
  
## 備考
None