### PR TITLE
[#123] 018コンポーネントのPresenterOutputとして返す値をUIImageからDataにする

### DIFF
--- a/Pendula/View/Component/018_LoadImages/Cell/LoadImagesCollectionViewCell.swift
+++ b/Pendula/View/Component/018_LoadImages/Cell/LoadImagesCollectionViewCell.swift
@@ -15,13 +15,13 @@ final class LoadImagesCollectionViewCell: UICollectionViewCell {
     private let placeholderImage = R.image.loadImages_placeholder()
 
     struct ViewModel {
-        let image: Data?
+        let imageData: Data?
         let rowText: String
         let lapText: String
     }
 
     func setup(viewModel: ViewModel) {
-        if let imageData = viewModel.image,
+        if let imageData = viewModel.imageData,
            let image = UIImage(data: imageData) {
             thumbnailImageView.image = image
         } else {

--- a/Pendula/View/Component/018_LoadImages/Cell/LoadImagesCollectionViewCell.swift
+++ b/Pendula/View/Component/018_LoadImages/Cell/LoadImagesCollectionViewCell.swift
@@ -15,13 +15,14 @@ final class LoadImagesCollectionViewCell: UICollectionViewCell {
     private let placeholderImage = R.image.loadImages_placeholder()
 
     struct ViewModel {
-        let image: UIImage?
+        let image: Data?
         let rowText: String
         let lapText: String
     }
 
     func setup(viewModel: ViewModel) {
-        if let image = viewModel.image {
+        if let imageData = viewModel.image,
+           let image = UIImage(data: imageData) {
             thumbnailImageView.image = image
         } else {
             thumbnailImageView.image = placeholderImage

--- a/Pendula/View/Component/018_LoadImages/LoadImagesCacher.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesCacher.swift
@@ -5,30 +5,30 @@
 //  Created by tokizo on 2021/12/05.
 //
 
-import UIKit
+import Foundation
 
 protocol LoadImagesCacher {
     /// 画像をキャッシュする
-    func cacheImage(url: URL, image: UIImage)
+    func cacheImage(url: URL, imageData: Data)
 
     /// キャッシュ済みの画像を返す（存在しない場合はnilを返す）
-    func getCachedImage(_ url: URL) -> UIImage?
+    func getCachedImageData(_ url: URL) -> Data?
 
 }
 
 final class LoadImagesCacherImplement: LoadImagesCacher {
 
-    private var imageDictionary: [URL: UIImage] = [:]
+    private var imageDictionary: [URL: Data] = [:]
 
     static let shared = LoadImagesCacherImplement()
 
     private init() {}
 
-    func cacheImage(url: URL, image: UIImage) {
-        imageDictionary[url] = image
+    func cacheImage(url: URL, imageData: Data) {
+        imageDictionary[url] = imageData
     }
 
-    func getCachedImage(_ url: URL) -> UIImage? {
+    func getCachedImageData(_ url: URL) -> Data? {
         return imageDictionary[url]
     }
 

--- a/Pendula/View/Component/018_LoadImages/LoadImagesCacher.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesCacher.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol LoadImagesCacher {
     /// 画像をキャッシュする
-    func cacheImage(url: URL, imageData: Data)
+    func cacheImageData(url: URL, imageData: Data)
 
     /// キャッシュ済みの画像を返す（存在しない場合はnilを返す）
     func getCachedImageData(_ url: URL) -> Data?
@@ -24,7 +24,7 @@ final class LoadImagesCacherImplement: LoadImagesCacher {
 
     private init() {}
 
-    func cacheImage(url: URL, imageData: Data) {
+    func cacheImageData(url: URL, imageData: Data) {
         imageDictionary[url] = imageData
     }
 

--- a/Pendula/View/Component/018_LoadImages/LoadImagesPresenter.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesPresenter.swift
@@ -53,7 +53,7 @@ final class LoadImagesPresenterImplement: LoadImagesPresenter {
             guard let imageData = try? Data(contentsOf: url) else {
                 return nil
             }
-            cacher.cacheImage(url: url, imageData: imageData)
+            cacher.cacheImageData(url: url, imageData: imageData)
             return imageData
         }
     }

--- a/Pendula/View/Component/018_LoadImages/LoadImagesPresenter.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesPresenter.swift
@@ -5,7 +5,7 @@
 //  Created by tokizo on 2021/11/27.
 //
 
-import UIKit
+import Foundation
 
 protocol LoadImagesPresenter {
     init(output: LoadImagesPresenterOutput, cacher: LoadImagesCacher)
@@ -33,32 +33,29 @@ final class LoadImagesPresenterImplement: LoadImagesPresenter {
     }
 
     func getImages() {
-        let images: [UIImage?] = urls.map {
+        let images: [Data?] = urls.map {
             return getImage(url: $0)
         }
 
-        output?.updateViewControllerModel(.init(thumbnailImages: images))
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.output?.updateViewControllerModel(.init(thumbnailImages: images))
+        }
     }
 
-    private func getImage(url: URL) -> UIImage? {
-        if let image = cacher.getCachedImage(url) {
-            return image
+    private func getImage(url: URL) -> Data? {
+        if let imageData = cacher.getCachedImageData(url) {
+            return imageData
 
         } else {
-            guard let image = fetchImage(url: url) else {
+            guard let imageData = try? Data(contentsOf: url) else {
                 return nil
             }
-            cacher.cacheImage(url: url, image: image)
-            return image
+            cacher.cacheImage(url: url, imageData: imageData)
+            return imageData
         }
-    }
-
-    private func fetchImage(url: URL) -> UIImage? {
-        guard let data = try? Data(contentsOf: url) else {
-            return nil
-        }
-
-        return .init(data: data)
     }
 
 }

--- a/Pendula/View/Component/018_LoadImages/LoadImagesPresenter.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesPresenter.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol LoadImagesPresenter {
     init(output: LoadImagesPresenterOutput, cacher: LoadImagesCacher)
-    func getImages()
+    func getImageDataList()
 }
 
 final class LoadImagesPresenterImplement: LoadImagesPresenter {
@@ -32,9 +32,9 @@ final class LoadImagesPresenterImplement: LoadImagesPresenter {
         self.cacher = cacher
     }
 
-    func getImages() {
+    func getImageDataList() {
         let images: [Data?] = urls.map {
-            return getImage(url: $0)
+            return getImageData(url: $0)
         }
 
         DispatchQueue.main.async { [weak self] in
@@ -45,7 +45,7 @@ final class LoadImagesPresenterImplement: LoadImagesPresenter {
         }
     }
 
-    private func getImage(url: URL) -> Data? {
+    private func getImageData(url: URL) -> Data? {
         if let imageData = cacher.getCachedImageData(url) {
             return imageData
 

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -19,7 +19,7 @@ final class LoadImagesViewController: ComponentBaseViewController {
     }
 
     struct ViewControllerModel {
-        let thumbnailImages: [UIImage?]
+        let thumbnailImages: [Data?]
     }
 
     private var viewControllerModel: ViewControllerModel?

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -42,7 +42,12 @@ final class LoadImagesViewController: ComponentBaseViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        presenter.getImages()
+        DispatchQueue.global().async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.presenter.getImages()
+        }
     }
 
 }

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -66,9 +66,9 @@ extension LoadImagesViewController: UICollectionViewDataSource {
 
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: R.reuseIdentifier.loadImagesCollectionViewCell,
                                                       for: indexPath)!
-        let image = viewControllerModel.thumbnailImages[indexPath.row]
+        let imageData = viewControllerModel.thumbnailImages[indexPath.row]
         let laps = indexPath.row / viewControllerModel.thumbnailImages.count
-        cell.setup(viewModel: .init(image: image,
+        cell.setup(viewModel: .init(imageData: imageData,
                                     rowText: indexPath.row.description,
                                     lapText: laps.description))
         return cell

--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -46,7 +46,7 @@ final class LoadImagesViewController: ComponentBaseViewController {
             guard let self = self else {
                 return
             }
-            self.presenter.getImages()
+            self.presenter.getImageDataList()
         }
     }
 


### PR DESCRIPTION
## Issue
#123 

  
## やったこと

- 018コンポーネントのPresenterOutputとして返す値をUIImageからDataにした
- 018コンポーネントでPresenterの取得処理を非メインスレッドにした

  
## スクリーンショット
  
|  before  |  after  |
| ---- | ---- |
| ![before](https://user-images.githubusercontent.com/37968814/146313126-81e4ac2b-631b-44af-8eac-93465a86d0a5.gif) |  ![after](https://user-images.githubusercontent.com/37968814/146313136-2028620b-f20e-45fc-9aef-8b551c8828fd.gif) |

表示速度をほんの少し早くすることができた。

 
## やらないこと
None
  
## 動作確認
018コンポーネントに遷移して遷移スピードを確認（人間では誤差レベルなのであくまで体験として遅くないか確認）
  
## レビューレベル
  
- [ ] Lv3: プロジェクト全体の動作に問題がないか確認する  
- [ ] Lv2: 影響があるコンポーネントの動作に問題がないか確認する  
- [x] Lv1: ぱっと見て問題ないか確認する  
  
## 参考
None
  
## 備考
None