### PR TITLE
[#130] 018コンポーネントのcollectionViewのスクロールが滑らかにいかないときがあるので改善する

### DIFF
--- a/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesFlowLayout.swift
@@ -58,7 +58,7 @@ final class LoadImagesFlowLayout: UICollectionViewFlowLayout {
         }
 
         // 見えてないCellも考慮するため、現在のoffsetの後ろから見るようにする
-        let expandedVisibleRect = CGRect(x: collectionView.contentOffset.x - collectionView.bounds.width,
+        let expandedVisibleRect = CGRect(x: collectionView.contentOffset.x - collectionView.bounds.width / 2,
                                          y: 0,
                                          width: collectionView.bounds.width * 2,
                                          height: collectionView.bounds.height)


### PR DESCRIPTION
## Issue
#130 

  
## やったこと
- ページスクロール時に必要なセルの情報を取得する際に、取得対象の領域の位置をx軸正の方向にずらした

  
## スクリーンショット
  
|  before  |  after  |
| ---- | ---- |
|  ![](https://user-images.githubusercontent.com/37968814/146635156-88562dd1-1204-44e3-9ffe-9d9359b9ab2a.gif) | ![after](https://user-images.githubusercontent.com/37968814/146641685-2e31b5e4-39be-42ad-b3b1-1bfd66260257.gif) |

beforeはスクロールが引っかかって次のセルに移動できない時がある
  


## やらないこと
None
  
## 動作確認
018コンポーネント画面でスクロールして引っかからずにスムーズな体験が得られればOK
  
## レビューレベル
  
- [ ] Lv3: プロジェクト全体の動作に問題がないか確認する  
- [ ] Lv2: 影響があるコンポーネントの動作に問題がないか確認する  
- [x] Lv1: ぱっと見て問題ないか確認する  
  
## 参考
None
  
## 備考
None