### PR TITLE
[#113]  UICollectionViewを右から左にスクロールできるようにする

### DIFF
--- a/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesViewController.swift
@@ -14,6 +14,7 @@ final class LoadImagesViewController: ComponentBaseViewController {
             collectionView.dataSource = self
             collectionView.delegate = self
             collectionView.decelerationRate = .fast
+            collectionView.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
             collectionView.register(R.nib.loadImagesCollectionViewCell)
         }
     }
@@ -71,6 +72,7 @@ extension LoadImagesViewController: UICollectionViewDataSource {
         cell.setup(viewModel: .init(imageData: imageData,
                                     rowText: indexPath.row.description,
                                     lapText: laps.description))
+        cell.transform = CGAffineTransform(scaleX: -1.0, y: 1.0)
         return cell
     }
 


### PR DESCRIPTION
## Issue
#113 

 
## やったこと
セルのスクロール方向を逆にした
  
## スクリーンショット
  
|  before  |  after  |
| ---- | ---- |
|  ![](https://user-images.githubusercontent.com/37968814/146641685-2e31b5e4-39be-42ad-b3b1-1bfd66260257.gif) |  ![after](https://user-images.githubusercontent.com/37968814/146643235-cce6cdb9-ad8b-4d45-9f9d-cab347df26aa.gif)|
  
## やらないこと
None
  
## 動作確認
018コンポーネントで右から左にスクロールができるようになっていればOK
  
## レビューレベル
  
- [ ] Lv3: プロジェクト全体の動作に問題がないか確認する  
- [ ] Lv2: 影響があるコンポーネントの動作に問題がないか確認する  
- [x] Lv1: ぱっと見て問題ないか確認する  
  
## 参考
None
  
## 備考
None