### PR TITLE
[#133] 018コンポーネントのURLの持ち方を改善する

### DIFF
--- a/Pendula/View/Component/018_LoadImages/LoadImagesAPIClient.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesAPIClient.swift
@@ -1,0 +1,68 @@
+//
+//  LoadImagesAPIClient.swift
+//  Pendula
+//
+//  Created by tokizo on 2021/12/19.
+//
+
+import Foundation
+
+protocol LoadImagesAPIClient {
+    func getImageURLs() -> [URL]
+}
+
+final class LoadImagesStubAPIClient: LoadImagesAPIClient {
+
+    func getImageURLs() -> [URL] {
+        return [
+            URL(string: "https://placehold.jp/edbcaf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/bbefba/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/cfdedc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/ccebdf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/edcffc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/bdddcb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/eccfca/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/faebed/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/caadfb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/baeefa/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/fccddf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/fabfca/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/baaceb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/ededeb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/adfafe/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/abdbfc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/bcbbca/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/aceeaf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/fecaec/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/abaadd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/aeadfd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/edacae/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/adfcdf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/ccbcea/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/aeddec/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/dcfdee/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/beffdf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/bdfecd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/aeffff/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/acaacc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/ecacfd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/cdeeca/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/feecaf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/dcecce/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/aabada/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/ccfefd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/edaeed/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/feffcb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/abcfdc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/dabbdc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/afdbbc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/ddeebf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/adceeb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/badabe/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/ebfece/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/fbcaab/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
+            URL(string: "https://placehold.jp/debadd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!
+        ]
+    }
+
+}

--- a/Pendula/View/Component/018_LoadImages/LoadImagesBuilder.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesBuilder.swift
@@ -14,8 +14,10 @@ struct LoadImagesBuilder: Builder {
     func build() -> ViewController {
         let vc = R.storyboard.loadImages.loadImages()!
         let cacher = LoadImagesCacherImplement.shared
+        let client = LoadImagesStubAPIClient()
         let presenter = LoadImagesPresenterImplement(output: vc,
-                                                     cacher: cacher)
+                                                     cacher: cacher,
+                                                     client: client)
         vc.presenter = presenter
         return vc
     }

--- a/Pendula/View/Component/018_LoadImages/LoadImagesPresenter.swift
+++ b/Pendula/View/Component/018_LoadImages/LoadImagesPresenter.swift
@@ -9,7 +9,8 @@ import Foundation
 
 protocol LoadImagesPresenter {
     init(output: LoadImagesPresenterOutput,
-         cacher: LoadImagesCacher)
+         cacher: LoadImagesCacher,
+         client: LoadImagesAPIClient)
     func getImageDataList()
 }
 
@@ -17,15 +18,18 @@ final class LoadImagesPresenterImplement: LoadImagesPresenter {
 
     private weak var output: LoadImagesPresenterOutput?
     private let cacher: LoadImagesCacher
+    private let client: LoadImagesAPIClient
 
     init(output: LoadImagesPresenterOutput,
-         cacher: LoadImagesCacher) {
+         cacher: LoadImagesCacher,
+         client: LoadImagesAPIClient) {
         self.output = output
         self.cacher = cacher
+        self.client = client
     }
 
     func getImageDataList() {
-        let urls = getURLs()
+        let urls = client.getImageURLs()
 
         let images: [Data?] = urls.map {
             return getImageData(url: $0)
@@ -50,62 +54,6 @@ final class LoadImagesPresenterImplement: LoadImagesPresenter {
             cacher.cacheImageData(url: url, imageData: imageData)
             return imageData
         }
-    }
-
-}
-
-extension LoadImagesPresenterImplement {
-
-    func getURLs() -> [URL] {
-        return [
-            URL(string: "https://placehold.jp/edbcaf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/bbefba/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/cfdedc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/ccebdf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/edcffc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/bdddcb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/eccfca/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/faebed/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/caadfb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/baeefa/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/fccddf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/fabfca/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/baaceb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/ededeb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/adfafe/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/abdbfc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/bcbbca/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/aceeaf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/fecaec/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/abaadd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/aeadfd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/edacae/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/adfcdf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/ccbcea/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/aeddec/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/dcfdee/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/beffdf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/bdfecd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/aeffff/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/acaacc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/ecacfd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/cdeeca/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/feecaf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/dcecce/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/aabada/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/ccfefd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/edaeed/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/feffcb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/abcfdc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/dabbdc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/afdbbc/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/ddeebf/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/adceeb/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/badabe/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/ebfece/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/fbcaab/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!,
-            URL(string: "https://placehold.jp/debadd/ffffff/1000x2000.png?text=1000%20%C3%97%202000")!
-        ]
     }
 
 }


### PR DESCRIPTION
## Issue
#133 
  
## やったこと
018コンポーネントのURLの持ち場所をPresenterから新たに定義したクラス内で保持するようにした

  
## スクリーンショット

差分が無いため割愛  


## やらないこと
None
  
## 動作確認

018コンポーネントを表示して、今まで表示が変わらないか。
（※ 今まで：[#132](https://github.com/tokizuoh/Pendula/pull/132) のafter）
  
## レビューレベル
  
- [ ] Lv3: プロジェクト全体の動作に問題がないか確認する  
- [ ] Lv2: 影響があるコンポーネントの動作に問題がないか確認する  
- [x] Lv1: ぱっと見て問題ないか確認する  
  
## 参考
None
  
## 備考
None